### PR TITLE
Fix element overlap for nav module

### DIFF
--- a/src/components/NavModule/NavModuleStyles.js
+++ b/src/components/NavModule/NavModuleStyles.js
@@ -47,6 +47,10 @@ export const NavTopLevel = styled.ul`
   padding: 0;
   margin: 0;
 
+  > li {
+    overflow: hidden;
+  }
+  
   > li,
   > li > button {
     text-transform: capitalize;


### PR DESCRIPTION
Root nav elements with drop downs prevent the next siblings root nav element from being clickable.  That is because the drop down elements are rendered on top of the root nav element, despite not being visible on screen.  Here's what it looks like when there is no `overflow:hidden`

![image](https://user-images.githubusercontent.com/249215/234955905-00008c0c-31f8-416a-b930-3e263e33af43.png)
